### PR TITLE
Correção da issue #3

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ void setup() {
 void loop() {
   // put your main code here, to run repeatedly:
   uint32_t tempo = millis();
-  if(!flags & (1 << flag_dist)){
+  if(~flags & (1 << flag_dist)){
     if(!digitalRead(bot)){
       delay(50);
       while(digitalRead(bot) == 0){
@@ -84,6 +84,8 @@ void loop() {
         digitalWrite(vermelho, HIGH);
         digitalWrite(amarelo, LOW);
         digitalWrite(verde, LOW);
+        delay(50);
+        return;
       }
       dist();
       delay(100);


### PR DESCRIPTION
## Objetivo
Fazer com que, ao retornar no modo distância, as luzes do semáforo inicializem na ordem correta. Anteriormente, todas iniciavam apagadas

## Ajustes efetuados
- Adicionado "return" após clique no botão, evitando que o código volte para a função "dist()" antes de efetuar o próximo loop, entrando diretamente na função do modo semáforo;
- Adicionado delay para debounce após o clique no botão, evitando que, ao clicar, além de retornar ao modo semáforo, a "solicitação de passagem" seja efetuada junto